### PR TITLE
Use '.' as decimal separator for the XML export

### DIFF
--- a/Constructor5/App.xaml.cs
+++ b/Constructor5/App.xaml.cs
@@ -5,6 +5,7 @@ using Constructor5.UI.Dialogs.ExceptionDialog;
 using Constructor5.UI.Dialogs.UnlocalizableStringFinder;
 using Constructor5.UI.Launcher;
 using Constructor5.UI.Main;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Threading;
 
@@ -24,6 +25,10 @@ namespace Constructor5
 
         private void Application_Startup(object sender, StartupEventArgs e)
         {
+            CultureInfo culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
+            culture.NumberFormat.NumberDecimalSeparator = ".";
+            System.Threading.Thread.CurrentThread.CurrentCulture = culture;
+
             StartupEvents.OnStartup();
 
 #if DEBUG


### PR DESCRIPTION
This seems relevant when the region format in Windows is set to one that uses a different character as decimal separator than '.' (i.e. German, which uses ',').

With this change, the XML serializer serializes doubles to a string with '.' as decimal separator, which seems to be what is required by Sims 4.