### PR TITLE
Fix Selectable object "something" is already assigned

### DIFF
--- a/Constructor5.Base/Startup/StartupEvents.cs
+++ b/Constructor5.Base/Startup/StartupEvents.cs
@@ -14,7 +14,14 @@ namespace Constructor5.Base.Startup
             {
                 foreach (var attribute in type.GetCustomAttributes<StartupTypeAttribute>())
                 {
-                    attribute.Invoke(type);
+                    try
+                    {
+                        attribute.Invoke(type);
+                    }
+                    catch(System.Exception ee)
+                    {
+                        Console.WriteLine(ee.Message);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Add a try/catch to fix the "Selectable object 'something' is already assigned" on startup that happens on some systems. For example: Selectable object FlirtyIntroductionInteraction is already assigned Please see issue #146